### PR TITLE
Make the sipdecider biased to 2 and 3

### DIFF
--- a/lib/controllers/cards_controller.dart
+++ b/lib/controllers/cards_controller.dart
@@ -186,7 +186,31 @@ class CardsController extends GetxController {
 
     for (var i = 0; i < _elements; i++) {
       // Random sips between 1 and 5, 6 is exclusive.
-      int sips = 1 + _rng.nextInt(6);
+      final _shuffledistribution = [
+        1,
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        4,
+        4,
+        4,
+        5,
+        5,
+        6,
+      ];
+      int sips = (_shuffledistribution.toList()..shuffle())
+          .elementAt(_rng.nextInt(_shuffledistribution.length));
+      print(sips);
       _rule = _rule.replaceAll("{[$i]}", sips.toString());
 //       print(rule);
       if (sips != 1) {

--- a/lib/controllers/cards_controller.dart
+++ b/lib/controllers/cards_controller.dart
@@ -192,6 +192,7 @@ class CardsController extends GetxController {
       if (sips != 1) {
         _rule = _rule.replaceAll("$sips time", "$sips times");
         _rule = _rule.replaceAll("$sips drink", "$sips drinks");
+        _rule = _rule.replaceAll("$sips sip", "$sips sips");
       }
     }
     return _rule;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Een niet betaalde zuip app.
 
 publish_to: "none"
 
-version: 0.4.0+1
+version: 0.4.1+1
 
 environment:
   sdk: ">=2.15.1 <3.0.0"


### PR DESCRIPTION
# What
The sipdecider now is biased towards the lower numbers, still within 1 and 6.
# Why
The high numbers were way to frequent and had to be toned down
# Noteworthy Changes
We now use a shuffled list with a gaussian distribution instead of NextInt because there is no easier way to do this.